### PR TITLE
Bumped version to fix the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.shipkit.shipkit-auto-version' version "0.0.25"
     id 'java-gradle-plugin'
-    id "com.gradle.plugin-publish" version "0.10.1"
+    id "com.gradle.plugin-publish" version "0.12.0"
     id 'groovy'
     id 'idea'
     id 'maven-publish'


### PR DESCRIPTION
Fixes the build that recently failed with:

```
* What went wrong:
Execution failed for task ':publishPlugins'.
> Failed to post to server.
  Server responded with:
  This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability.
  Please update to the latest version of the com.gradle.plugin-publish plugin found here:
     https://plugins.gradle.org/plugin/com.gradle.plugin-publish

  You can read more about this vulnerability here:
     https://blog.gradle.org/plugin-portal-update
```

See: https://github.com/shipkit/shipkit-auto-version/runs/726451699?check_suite_focus=true