### PR TITLE
Improved how the version is logged to the console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ repositories {
 }
 
 dependencies {
-    //TODO: fat jar, to be on the safe side, update the documentation
     implementation 'com.github.zafarkhaja:java-semver:0.9.0'
 
     testImplementation 'junit:junit:4.12'

--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -7,7 +7,6 @@ import org.gradle.api.logging.Logging;
 import java.io.File;
 import java.util.Optional;
 
-import static java.lang.Integer.parseInt;
 import static java.util.Arrays.asList;
 
 /**
@@ -34,35 +33,39 @@ class AutoVersion {
         return deductVersion(LOG);
     }
 
+    private static void explainVersion(Logger log, String version, String reason) {
+        log.lifecycle("Building version '"+ version + "'\n" +
+                "  - reason: shipkit-auto-version " + reason);
+    }
+
     String deductVersion(Logger log) {
         String spec = VersionSpec.readVersionSpec(versionFile);
         if (!spec.endsWith("*")) {
             //if there is no wildcard we will use the version 'as is'
-            log.lifecycle("shipkit-auto-version is setting explicit version '" + spec +
-                    "' as declared in '" + versionFile.getName() + "' file.");
+            explainVersion(log, spec, "uses verbatim version from '" + versionFile.getName() + "' file");
             return spec;
         }
 
         try {
-            return deductVersion(spec);
+            return deductVersion(spec, log);
         } catch (Exception e) {
-            String message = "shipkit-auto-version was unable to deduct the version due to an exception";
-            log.debug(message, e);
+            String message = "caught an exception, falling back to reasonable default";
+            log.debug("shipkit-auto-version " + message, e);
             String v = spec.replace("*", "unspecified");
-            log.lifecycle(message + ".\n" +
-                    "  - setting version to '" + v + "' (run with --debug for more info)");
+            explainVersion(log, v, message + "\n  - run with --debug for more info");
             return v;
         }
     }
 
-    String deductVersion(String spec) {
+    String deductVersion(String spec, Logger log) {
         String gitOutput = runner.run("git", "tag");
         String[] tags = gitOutput.split(System.lineSeparator());
         Optional<Version> nearest = new NearestTagFinder().findTag(asList(tags), spec);
         if (!nearest.isPresent()) {
             //if there is no nearest matching tag (same major, same minor) we can just use '0' for the wildcard
             String version = spec.replace("*", "0");
-            LOG.lifecycle("shipkit-auto-version plugin found no tags, setting version to '" + version + "'");
+            //TODO add information 'found no tags matching ...'
+            explainVersion(log, version, "found no tags");
             return version;
         }
 
@@ -76,7 +79,7 @@ class AutoVersion {
                 tag.getMajorVersion(), tag.getMinorVersion(), tag.getPatchVersion() + commitCount);
 
         String v = result.toString();
-        LOG.lifecycle("shipkit-auto-version plugin found previous tag '" + tag + "', setting version to '" + v + "'");
+        explainVersion(log, v, "deducted version based on previous tag: '" + tag + "'");
         return v;
     }
 }


### PR DESCRIPTION
- Removed TODO about fat jar dependency. There is no point to fat-jar this dependency because it is safe (no code changes since 2015, no foreseeable new changes/versions given that semver did not change since 2013).
- tightened test coverage. For this plugin we need to make sure that the messages we print to the customers are correct.