### PR TITLE
Support windows Gradle builds

### DIFF
--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -59,7 +59,7 @@ class AutoVersion {
 
     String deductVersion(String spec, Logger log) {
         String gitOutput = runner.run("git", "tag");
-        String[] tags = gitOutput.split(System.lineSeparator());
+        String[] tags = gitOutput.split("\\R");
         Optional<Version> nearest = new NearestTagFinder().findTag(asList(tags), spec);
         if (!nearest.isPresent()) {
             //if there is no nearest matching tag (same major, same minor) we can just use '0' for the wildcard

--- a/src/main/java/org/shipkit/auto/version/CommitCounter.java
+++ b/src/main/java/org/shipkit/auto/version/CommitCounter.java
@@ -42,7 +42,7 @@ class CommitCounter {
      */
     int countCommitDelta(String gitOutput) {
         gitOutput = gitOutput.trim();
-        String[] lines = gitOutput.split(System.lineSeparator());
+        String[] lines = gitOutput.split("\\R");
         Pattern pattern = Pattern.compile(".* Merge pull request #\\d+ from .*");
         int commits = 0;
         int mergeCommits = 0;


### PR DESCRIPTION
Use \R regex expression to match all new line characters.
Git for Windows (2.27.0) doesn't use CR new line characters.