### PR TITLE
Bumped version of the shipkit-auto-version plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,11 @@
 plugins {
-    id 'org.shipkit.shipkit-auto-version' version "0.0.25"
+    id 'org.shipkit.shipkit-auto-version' version "0.0.32"
     id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "0.12.0"
     id 'groovy'
     id 'idea'
     id 'maven-publish'
 }
-
-println "Building version $version"
 
 group = "org.shipkit"
 


### PR DESCRIPTION
Bumped version of the plugin to the latest 0.0.32. Also done clean-up in build.gradle file - line informing about version being built is now removed, because new version of the plugin prints it automatically.
The update was tested by running the build. Plugin correctly informs about version being built and all generated files have proper version.