### PR TITLE
Enabled generation of changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       run: ./gradlew build --scan --continue
     - name: Push tag and deploy to plugins.gradle.org
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
-      run: ./gradlew createTag publishPlugins --scan
+      run: ./gradlew createTag publishPlugins githubRelease --scan
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:0.0.34"
-        classpath "org.shipkit:shipkit-changelog:0.0.3"
+        classpath "org.shipkit:shipkit-auto-version:0.0.+"
+        classpath "org.shipkit:shipkit-changelog:0.0.+"
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }
 }
@@ -17,6 +17,7 @@ apply plugin: 'groovy'
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: "org.shipkit.shipkit-auto-version"
 apply plugin: "org.shipkit.shipkit-changelog"
+apply plugin: "org.shipkit.shipkit-gh-release"
 
 group = "org.shipkit"
 
@@ -46,10 +47,4 @@ publishing { // docs: https://docs.gradle.org/current/userguide/publishing_maven
             from components.java
         }
     }
-}
-
-tasks.named("generateChangelog") {
-    previousRevision = "v0.0.34" //TODO replace with dynamically calculated previous version
-    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
-    repository = "shipkit/shipkit-auto-version"
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -41,3 +41,16 @@ task createTag {
         println "Created tag $tagName"
     }
 }
+
+tasks.named("generateChangelog") {
+    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    repository = "shipkit/shipkit-changelog"
+}
+
+tasks.named("githubRelease") {
+    dependsOn tasks.named("generateChangelog")
+    repository = "shipkit/shipkit-changelog"
+    changelog = tasks.named("generateChangelog").get().outputFile
+    writeToken = System.getenv("GH_WRITE_TOKEN")
+}

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -42,15 +42,17 @@ task createTag {
     }
 }
 
+def genTask = tasks.named("generateChangelog").get()
+
 tasks.named("generateChangelog") {
     previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
     readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
-    repository = "shipkit/shipkit-changelog"
+    repository = genTask.repository
 }
 
 tasks.named("githubRelease") {
-    dependsOn tasks.named("generateChangelog")
-    repository = "shipkit/shipkit-changelog"
-    changelog = tasks.named("generateChangelog").get().outputFile
+    dependsOn genTask
+    repository = genTask.repository
+    changelog = genTask.outputFile
     writeToken = System.getenv("GH_WRITE_TOKEN")
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -42,15 +42,14 @@ task createTag {
     }
 }
 
-def genTask = tasks.named("generateChangelog").get()
-
 tasks.named("generateChangelog") {
     previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
     readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
-    repository = genTask.repository
+    repository = "shipkit/shipkit-changelog"
 }
 
 tasks.named("githubRelease") {
+    def genTask = tasks.named("generateChangelog").get()
     dependsOn genTask
     repository = genTask.repository
     changelog = genTask.outputFile


### PR DESCRIPTION
In order to enable changelog and automate generation of release notes tasks "generateChangelog" and "githubRelease" were added to release.gradle (and "generateChangelog" was removed from build.gradle). 
Also in build.gradle replaced version of shipkit-auto-version and shipkitChangelog with "0.0.+". 
githubRelease is now included in CI build steps in build.yml.