### PR TITLE
Started fetching full history

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,12 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2   # docs: https://github.com/actions/checkout
-    - name: Fetch all tags
-      run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*      
+      with:
+        # we need a good number of commits to fetch, to generate the release notes
+        # we also need tags so that we can deduct the version
+        # this project is small, so we will fetch all history ('0')
+        # if fetching gets slow we can define a specific # of commits (e.g. '1000')
+        fetch-depth: '0'
     - name: Run build
       run: .\gradlew.bat build --scan --continue
 


### PR DESCRIPTION
We need more history / commits otherwise we are not generating the release notes reliably.

Fixes https://github.com/shipkit/shipkit-changelog/issues/21

Given that we are now fetching the entire history, I removed the "fetch all tags" step from the build. This makes the build faster by about ~10 secs. Fetching the entire history for this project adds ~3 secs to checkout, but removal of the "fetch all tags" step writes off ~13 secs from the build. Nice ;-)