### PR TITLE
Allow convenient version override for -SNAPSHOT development

### DIFF
--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -47,7 +47,7 @@ class AutoVersion {
     //Exposed for testing so that 'log' can be mocked
     DeductedVersion deductVersion(Logger log, String projectVersion) {
         if (!Project.DEFAULT_VERSION.equals(projectVersion)) {
-            explainVersion(log, projectVersion, "Version was already defined on project.");
+            explainVersion(log, projectVersion, "uses version already specified in the Gradle project");
             return new DeductedVersion(projectVersion, null);
         }
 

--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -1,6 +1,7 @@
 package org.shipkit.auto.version;
 
 import com.github.zafarkhaja.semver.Version;
+import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 
@@ -31,9 +32,11 @@ class AutoVersion {
 
     /**
      * Deduct version based on existing tags (will run 'git tag'), and the version spec from versionFile field.
+     *
+     * @param projectVersion the version of the gradle project before running the plugin
      */
-    DeductedVersion deductVersion() {
-        return deductVersion(LOG);
+    DeductedVersion deductVersion(String projectVersion) {
+        return deductVersion(LOG, projectVersion);
     }
 
     private static void explainVersion(Logger log, String version, String reason) {
@@ -42,7 +45,12 @@ class AutoVersion {
     }
 
     //Exposed for testing so that 'log' can be mocked
-    DeductedVersion deductVersion(Logger log) {
+    DeductedVersion deductVersion(Logger log, String projectVersion) {
+        if (!Project.DEFAULT_VERSION.equals(projectVersion)) {
+            explainVersion(log, projectVersion, "Version was already defined on project.");
+            return new DeductedVersion(projectVersion, null);
+        }
+
         String spec = VersionSpec.readVersionSpec(versionFile);
         if (!spec.endsWith("*")) {
             //if there is no wildcard we will use the version 'as is'

--- a/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
@@ -3,19 +3,14 @@ package org.shipkit.auto.version;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
-
 /**
  * The plugin, ideally with zero business logic, but only the Gradle integration code
  */
 public class AutoVersionPlugin implements Plugin<Project> {
 
-  public void apply(Project project) {
-    DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion();
-    if (project.getVersion().equals(Project.DEFAULT_VERSION)) {
-      project.allprojects(p -> p.setVersion(version.getVersion()));
+    public void apply(Project project) {
+        DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion(project.getVersion().toString());
+        project.allprojects(p -> p.setVersion(version.getVersion()));
+        project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-version", version.getPreviousVersion());
     }
-    project.getExtensions()
-        .getExtraProperties()
-        .set("shipkit-auto-version.previous-version", version.getPreviousVersion());
-  }
 }

--- a/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
@@ -3,14 +3,19 @@ package org.shipkit.auto.version;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
+
 /**
  * The plugin, ideally with zero business logic, but only the Gradle integration code
  */
 public class AutoVersionPlugin implements Plugin<Project> {
 
-    public void apply(Project project) {
-        DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion();
-        project.allprojects(p -> p.setVersion(version.getVersion()));
-        project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-version", version.getPreviousVersion());
+  public void apply(Project project) {
+    DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion();
+    if (project.getVersion().equals(Project.DEFAULT_VERSION)) {
+      project.allprojects(p -> p.setVersion(version.getVersion()));
     }
+    project.getExtensions()
+        .getExtraProperties()
+        .set("shipkit-auto-version.previous-version", version.getPreviousVersion());
+  }
 }

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionPluginTest.groovy
@@ -1,5 +1,7 @@
 package org.shipkit.auto.version
 
+
+import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
@@ -32,7 +34,7 @@ class AutoVersionPluginTest extends Specification {
         runner.run("git", "merge", "PR-10", "--no-ff", "-m", "Merge pull request #10 from ...")
 
         when:
-        def v = new AutoVersion(project.projectDir).deductVersion()
+        def v = new AutoVersion(project.projectDir).deductVersion(Project.DEFAULT_VERSION)
 
         then:
         v.version == "1.0.1"

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
@@ -80,13 +80,6 @@ some commit #2
     }
 
     def "uses project version if not default"() {
-        versionFile << "version=2.0.*"
-        runner.run("git", "tag") >> "v2.0.0"
-        runner.run("git", "log", "--pretty=oneline", "v2.0.0..HEAD") >> """
-some commit #1
-some commit #2
-"""
-
         when:
         def v = autoVersion.deductVersion(log, "2.0.5-SNAPSHOT")
 
@@ -94,6 +87,6 @@ some commit #2
         v.version == "2.0.5-SNAPSHOT"
         v.previousVersion == null
         1 * log.lifecycle("Building version '2.0.5-SNAPSHOT'\n" +
-            "  - reason: shipkit-auto-version Version was already defined on project.")
+            "  - reason: shipkit-auto-version uses version already specified in the Gradle project")
     }
 }

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
@@ -1,5 +1,7 @@
 package org.shipkit.auto.version
 
+
+import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 
 class AutoVersionTest extends TmpFolderSpecification {
@@ -18,7 +20,7 @@ class AutoVersionTest extends TmpFolderSpecification {
         versionFile << "version=1.5.0-SNAPSHOT"
 
         when:
-        def v = autoVersion.deductVersion(log)
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
 
         then:
         v.version == "1.5.0-SNAPSHOT"
@@ -35,7 +37,7 @@ v1.0.1
 """
 
         when:
-        def v = autoVersion.deductVersion(log)
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
 
         then:
         v.version == "1.1.0"
@@ -53,7 +55,7 @@ some commit #2
 """
 
         when:
-        def v = autoVersion.deductVersion(log)
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
 
         then:
         v.version == "2.0.2"
@@ -66,7 +68,7 @@ some commit #2
         versionFile << "version=1.0.*"
 
         when:
-        def v = autoVersion.deductVersion(log)
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
 
         then:
         v.version == "1.0.unspecified"
@@ -75,5 +77,23 @@ some commit #2
         1 * log.lifecycle("Building version '1.0.unspecified'\n" +
                 "  - reason: shipkit-auto-version caught an exception, falling back to reasonable default\n" +
                 "  - run with --debug for more info")
+    }
+
+    def "uses project version if not default"() {
+        versionFile << "version=2.0.*"
+        runner.run("git", "tag") >> "v2.0.0"
+        runner.run("git", "log", "--pretty=oneline", "v2.0.0..HEAD") >> """
+some commit #1
+some commit #2
+"""
+
+        when:
+        def v = autoVersion.deductVersion(log, "2.0.5-SNAPSHOT")
+
+        then:
+        v.version == "2.0.5-SNAPSHOT"
+        v.previousVersion == null
+        1 * log.lifecycle("Building version '2.0.5-SNAPSHOT'\n" +
+            "  - reason: shipkit-auto-version Version was already defined on project.")
     }
 }


### PR DESCRIPTION
This allows users to set the version when building via gradle with the `-Pversion` flag, which allows for custom versioning, which is useful when building locally (e.g. `-Pversion=1.0.0-SNAPSHOT`).

closes #37 