### PR TITLE
Remove redundant check from CI workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run build
       run: ./gradlew build --scan --continue
     - name: Push tag and deploy to plugins.gradle.org
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       run: ./gradlew publishPlugins githubRelease --scan
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables


### PR DESCRIPTION
_success()_ check from CI workflow can be removed (if previous step doesn't pass, next is not executed as default).