### PR TITLE
Enabled Gradle enterprise, added docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # We run Windows build first because we will be publishing artifacts from the Ubuntu build (simplifies workflow)
     needs: windows_build
 
     steps:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,12 @@
+plugins {
+    id "com.gradle.enterprise" version "3.5"
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
+}
+
 rootProject.name = "shipkit-auto-version"

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
+        uploadInBackground = System.getenv("CI") == null
     }
 }
 


### PR DESCRIPTION
Enabled Gradle enterprise plugin. This way, when running with "--scan" flag (like we do on CI) will correctly publish a build scan.

Also added some documentation.