### PR TITLE
Revert "Bumped to 1.0 major version"

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,1 @@
-# Version of the produced binaries.
-# The version is inferred by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version)
-version=1.0.*
+version=0.0.*


### PR DESCRIPTION
Reverts shipkit/shipkit-auto-version#41

It caused build failure. We need to fix this first: https://github.com/shipkit/shipkit-auto-version/issues/42

I'll merge right away because it's a clean revert.