### PR TITLE
Updated CI workflow to avoid failures in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
       run: ./gradlew build --scan --continue
     - name: Push tag and deploy to plugins.gradle.org
       if: github.event_name == 'push' 
-          && github.ref == 'refs/heads/master' 
+          && github.ref == 'refs/heads/master'
+          && github.repository == 'shipkit/shipkit-auto-version'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
       run: ./gradlew publishPlugins githubRelease --scan
       env:


### PR DESCRIPTION
Repository path test in CI workflow will prevent getting "release" job failures, which are being get by contributors' in GH Actions, when they push commits to their forks.
Same change was earlier done here: https://github.com/mockito/mockito/commit/f5419b0638b6b517a7d29991bf29639988242335