### PR TITLE
Simplify getting previous revision

### DIFF
--- a/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
@@ -12,5 +12,11 @@ public class AutoVersionPlugin implements Plugin<Project> {
         DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion(project.getVersion().toString());
         project.allprojects(p -> p.setVersion(version.getVersion()));
         project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-version", version.getPreviousVersion());
+
+        if (version.getPreviousVersion() != null) {
+            project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-tag", "v"+version.getPreviousVersion());
+        } else {
+            project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-tag", null);
+        }
     }
 }

--- a/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersionPlugin.java
@@ -12,11 +12,6 @@ public class AutoVersionPlugin implements Plugin<Project> {
         DeductedVersion version = new AutoVersion(project.getProjectDir()).deductVersion(project.getVersion().toString());
         project.allprojects(p -> p.setVersion(version.getVersion()));
         project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-version", version.getPreviousVersion());
-
-        if (version.getPreviousVersion() != null) {
-            project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-tag", "v"+version.getPreviousVersion());
-        } else {
-            project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-tag", null);
-        }
+        project.getExtensions().getExtraProperties().set("shipkit-auto-version.previous-tag", version.getPreviousTag());
     }
 }

--- a/src/main/java/org/shipkit/auto/version/DeductedVersion.java
+++ b/src/main/java/org/shipkit/auto/version/DeductedVersion.java
@@ -13,11 +13,13 @@ class DeductedVersion {
 
     private final String version;
     private final String previousVersion;
+    private final String previousTag;
 
     DeductedVersion(String version, Optional<Version> previousVersion) {
         Objects.requireNonNull(version, "version cannot be null");
         this.version = version;
         this.previousVersion = previousVersion.map(Version::toString).orElse(null);
+        this.previousTag = previousVersion.isPresent() ? TagConvention.tagFor(this.previousVersion) : null;
     }
 
     /**
@@ -36,5 +38,10 @@ class DeductedVersion {
     @Nullable
     String getPreviousVersion() {
         return previousVersion;
+    }
+
+    @Nullable
+    String getPreviousTag() {
+        return previousTag;
     }
 }

--- a/src/main/java/org/shipkit/auto/version/DeductedVersion.java
+++ b/src/main/java/org/shipkit/auto/version/DeductedVersion.java
@@ -40,6 +40,14 @@ class DeductedVersion {
         return previousVersion;
     }
 
+    /**
+     * Previous tag.
+     * Returned value is the previous version with 'v' prefix added in accordance
+     * with supported, in {@link TagConvention} class, tag naming convention
+     * (e.g. for previous version 1.0.0 the previous tag could be v1.0.0).
+     * The returned previous tag value can be null when previous version is null:
+     * {@link #getPreviousVersion()}
+     */
     @Nullable
     String getPreviousTag() {
         return previousTag;

--- a/src/main/java/org/shipkit/auto/version/DeductedVersion.java
+++ b/src/main/java/org/shipkit/auto/version/DeductedVersion.java
@@ -19,7 +19,7 @@ class DeductedVersion {
         Objects.requireNonNull(version, "version cannot be null");
         this.version = version;
         this.previousVersion = previousVersion.map(Version::toString).orElse(null);
-        this.previousTag = previousVersion.isPresent() ? TagConvention.tagFor(this.previousVersion) : null;
+        this.previousTag = previousVersion.map(v -> TagConvention.tagFor(v.toString())).orElse(null);
     }
 
     /**

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionPluginTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionPluginTest.groovy
@@ -38,5 +38,6 @@ class AutoVersionPluginTest extends Specification {
         then:
         project.version == "1.0.1"
         project.ext.'shipkit-auto-version.previous-version' == "1.0.0"
+        project.ext.'shipkit-auto-version.previous-tag' == "v1.0.0"
     }
 }

--- a/src/test/groovy/org/shipkit/auto/version/DeductedVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/DeductedVersionTest.groovy
@@ -10,4 +10,10 @@ class DeductedVersionTest extends Specification {
         "0.0.9" == new DeductedVersion("1.0.0", Optional.of(Version.valueOf("0.0.9"))).previousVersion
         null == new DeductedVersion("1.0.0", Optional.empty()).previousVersion
     }
+
+    def "nullable previous tag"() {
+        expect:
+        "v0.0.9" == new DeductedVersion("1.0.0", Optional.of(Version.valueOf("0.0.9"))).previousTag
+        null == new DeductedVersion("1.0.0", Optional.empty()).previousTag
+    }
 }


### PR DESCRIPTION
This PR resolves https://github.com/shipkit/shipkit-auto-version/issues/52
To avoid unwanted complexity of getting project's previous version with _shipkit-auto-version.previous-version_ property another property is exposed: _shipkit-auto-version.previous-tag_. Earlier to get previous revision (e.g. for generating chengelog with Shipkit Changelog plugin) concatenation and possible conditional had to be used. Now it requires just to refer to _shipkit-auto-version.previous-tag_ alone.
There is new field _previousTag_ added in _DeductedVersion_ class, which is initialized with value based on project's previous version. To initialize this field with proper value, existing _TagConvention.tagFor()_ method is used, what provides fixed tag naming convention. These changes are covered with test in _DeductedVersionTest_ (both happy and unhappy path when there is no previous version). Getting previous tag is covered with javadoc.