### PR TITLE
Start using 'previous-tag' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ has negligible performance implication (adds ~2 secs to the checkout).
 This plugin exposes an 'ext' property `shipkit-auto-version.previous-version` that can be used to get access to the previous version.
 Example:
 
-```
+```groovy
 println project.ext.'shipkit-auto-version.previous-version'
 ```
 ### shipkit-auto-version.previous-tag
@@ -65,10 +65,10 @@ version's tag. It allows to get previous revision in convenient way (eg. for gen
 plugin as in example below).
 Example:
 
-```
+```groovy
 tasks.named("generateChangelog") {
    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-   ...
+   //...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,13 +50,25 @@ has negligible performance implication (adds ~2 secs to the checkout).
     fetch-depth: '0' # will fetch the entire history
 ```
 
-## shipkit-auto-version.previous-version
+## shipkit-auto-version.previous-version, shipkit-auto-version.previous-tag
 
-This plugin exposes an 'ext' property `shipkit-auto-version.previous-version` that can be used to get access to the previous version.
+This plugin exposes 'ext' property `shipkit-auto-version.previous-version` that can be used to get access to the previous version.
 Example:
 
 ```
 println project.ext.'shipkit-auto-version.previous-version'
+```
+
+Shipkit Auto Version exposes also an 'ext' property `shipkit-auto-version.previous-tag` that gives access to the previous
+version's tag. It allows to get previous revision in convenient way (eg. for generating changelog with Shipkit Changelog
+plugin as in example below).
+Example:
+
+```
+tasks.named("generateChangelog") {
+   previousRevision = project.ext.'shipkit-auto-version.previous-tag'
+   ...
+}
 ```
 
 ## Version Overriding

--- a/README.md
+++ b/README.md
@@ -50,16 +50,17 @@ has negligible performance implication (adds ~2 secs to the checkout).
     fetch-depth: '0' # will fetch the entire history
 ```
 
-## shipkit-auto-version.previous-version, shipkit-auto-version.previous-tag
+## Properties exposed by the plugin
 
-This plugin exposes 'ext' property `shipkit-auto-version.previous-version` that can be used to get access to the previous version.
+### shipkit-auto-version.previous-version
+This plugin exposes an 'ext' property `shipkit-auto-version.previous-version` that can be used to get access to the previous version.
 Example:
 
 ```
 println project.ext.'shipkit-auto-version.previous-version'
 ```
-
-Shipkit Auto Version exposes also an 'ext' property `shipkit-auto-version.previous-tag` that gives access to the previous
+### shipkit-auto-version.previous-tag
+Shipkit Auto Version exposes also `shipkit-auto-version.previous-tag` 'ext' property that gives access to the previous
 version's tag. It allows to get previous revision in convenient way (eg. for generating changelog with Shipkit Changelog
 plugin as in example below).
 Example:

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -35,7 +35,7 @@ if (ext.'gradle.publish.key' && ext.'gradle.publish.secret') {
 }
 
 tasks.named("generateChangelog") {
-    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    previousRevision = 'shipkit-auto-version.previous-tag'
     readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
     repository = "shipkit/shipkit-auto-version"
 }


### PR DESCRIPTION
Recently new property _'shipkit-auto-version.previous-tag'_ has been exposed. It allows for getting previous revision in more convenient way. This is done in release.gradle file with first commit of this PR - instead of _'previous-version'_ property, the _'previous-tag'_ is used. New property is now also covered with README.md documentation (accordig to @mockitoguy suggestions, corrected a bit to make it more readable).