### PR TITLE
Update workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         fetch-depth: '0'  # https://github.com/shipkit/shipkit-auto-version#fetch-depth-on-ci
     - name: Run build
-      run: .\gradlew.bat build --scan --continue
+      run: .\gradlew.bat build --continue
 
   build:
 
@@ -46,13 +46,13 @@ jobs:
       with:
         fetch-depth: '0'  # https://github.com/shipkit/shipkit-auto-version#fetch-depth-on-ci
     - name: Run build
-      run: ./gradlew build --scan --continue
+      run: ./gradlew build --continue
     - name: Push tag and deploy to plugins.gradle.org
       if: github.event_name == 'push'
           && github.ref == 'refs/heads/master'
           && github.repository == 'shipkit/shipkit-auto-version'
           && !contains(toJSON(github.event.commits.*.message), '[skip release]')
-      run: ./gradlew publishPlugins githubRelease --scan
+      run: ./gradlew publishPlugins githubRelease
       env:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,4 @@ jobs:
           # Gradle env variables docs: https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
           GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
-          GH_WRITE_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -36,7 +36,7 @@ if (ext.'gradle.publish.key' && ext.'gradle.publish.secret') {
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    githubToken = System.getenv("GITHUB_TOKEN")
     repository = "shipkit/shipkit-auto-version"
 }
 
@@ -45,6 +45,6 @@ tasks.named("githubRelease") {
     dependsOn genTask
     repository = genTask.repository
     changelog = genTask.outputFile
-    writeToken = System.getenv("GH_WRITE_TOKEN")
+    githubToken = System.getenv("GITHUB_TOKEN")
     newTagRevision = System.getenv("GITHUB_SHA")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,10 @@ gradleEnterprise {
     buildScan {
         termsOfServiceUrl = "https://gradle.com/terms-of-service"
         termsOfServiceAgree = "yes"
-        uploadInBackground = System.getenv("CI") == null
+        if (System.getenv("CI")) {
+            publishAlways()
+            uploadInBackground = false
+        }
     }
 }
 


### PR DESCRIPTION
1. Removing _'--scan'_ argument from _ci.yml_ workflow file and moving the control of scan publishing to _settings.gradle_ makes configuration simpler to set.
2. Recently new _'githubToken'_ property was added to Shipkit Changelog plugin. This property is used to authenticate in Github Api, both to fetch and write, instead of _'readOnlyToken'_ and _'writeToken'_. We should replace deprecated properties with the new one.