### PR TITLE
Aplly renamed plugin package

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -2,7 +2,7 @@ apply plugin: "java-gradle-plugin"
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: "org.shipkit.shipkit-auto-version"
 apply plugin: "org.shipkit.shipkit-changelog"
-apply plugin: "org.shipkit.shipkit-gh-release"
+apply plugin: "org.shipkit.shipkit-github-release"
 
 // docs: https://plugins.gradle.org/docs/publish-plugin
 gradlePlugin {


### PR DESCRIPTION
Due to recent Github related naming convention applied in Shipkit Changelog plugin, the referenced _'org.shipkit.shipkit-gh-release'_ package should be changed for _'org.shipkit.shipkit-github-release'_.