### PR TITLE
Bump Shipkit plugins versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:0.+"
-        classpath "org.shipkit:shipkit-changelog:0.+"
+        classpath "org.shipkit:shipkit-auto-version:1.+"
+        classpath "org.shipkit:shipkit-changelog:1.+"
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
     }
 }


### PR DESCRIPTION
Recently new versions of Shipkit Auto Version and Shipkit Changelog were published. The plugins' versions in the project can now be bumped.