### PR TITLE
Removed deprecated jCenter()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ group = "org.shipkit"
 sourceCompatibility = 1.8
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
As JCenter is going to be shut down in the near future, dependencies' repository can be replaced with mavenCentral().