### PR TITLE
Remove duplicated 'tagPrefix' parameter 

### DIFF
--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -46,7 +46,7 @@ class AutoVersion {
             Collection<Version> versions = new VersionsProvider(runner).getAllVersions(config.getTagPrefix());
             previousVersion = new PreviousVersionFinder().findPreviousVersion(versions, config);
             String nextVersion = new NextVersionPicker(runner, log).pickNextVersion(previousVersion,
-                    config, projectVersion, config.getTagPrefix());
+                    config, projectVersion);
             return new DeductedVersion(nextVersion, previousVersion, config.getTagPrefix());
         } catch (Exception e) {
             String message = "caught an exception, falling back to reasonable default";

--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -21,8 +21,7 @@ class NextVersionPicker {
     /**
      * Picks the next version to use based on the input parameters
      */
-    String pickNextVersion(Optional<Version> previousVersion, VersionConfig config, String projectVersion,
-                           String tagPrefix) {
+    String pickNextVersion(Optional<Version> previousVersion, VersionConfig config, String projectVersion) {
         if (!Project.DEFAULT_VERSION.equals(projectVersion)) {
             explainVersion(log, projectVersion, "uses version already specified in the Gradle project");
             return projectVersion;
@@ -37,7 +36,7 @@ class NextVersionPicker {
         if (previousVersion.isPresent() && previousVersion.get().satisfies(config.toString())) {
             Version prev = previousVersion.get();
             String gitOutput = runner.run(
-                    "git", "log", "--pretty=oneline", TagConvention.tagFor(prev.toString(), tagPrefix) + "..HEAD");
+                    "git", "log", "--pretty=oneline", TagConvention.tagFor(prev.toString(), config.getTagPrefix()) + "..HEAD");
             int commitCount = new CommitCounter().countCommitDelta(gitOutput);
             String result = Version
                     .forIntegers(

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -18,7 +18,7 @@ class NextVersionPickerTest extends Specification {
     def "picks version as configured on the Gradle project"() {
         when:
         def v = picker.pickNextVersion(
-                Optional.empty(), new VersionConfig("1.0.*", "v"), "1.1.0", "v")
+                Optional.empty(), new VersionConfig("1.0.*", "v"), "1.1.0")
 
         then:
         v == "1.1.0"
@@ -29,7 +29,7 @@ class NextVersionPickerTest extends Specification {
     def "picks version 'as is' because the wildcard is not used"() {
         when:
         def v = picker.pickNextVersion(
-                Optional.empty(), new VersionConfig("1.0.0", "v"), Project.DEFAULT_VERSION, "v")
+                Optional.empty(), new VersionConfig("1.0.0", "v"), Project.DEFAULT_VERSION)
 
         then:
         v == "1.0.0"
@@ -40,7 +40,7 @@ class NextVersionPickerTest extends Specification {
     def "picks new patch version when no previous version"() {
         when:
         def v = picker.pickNextVersion(
-                Optional.empty(), new VersionConfig("1.0.*", "v"), Project.DEFAULT_VERSION, "v")
+                Optional.empty(), new VersionConfig("1.0.*", "v"), Project.DEFAULT_VERSION)
 
         then:
         v == "1.0.0"
@@ -53,7 +53,7 @@ class NextVersionPickerTest extends Specification {
         def v = picker.pickNextVersion(
                 Optional.of(Version.valueOf("0.0.9")),
                 new VersionConfig("1.0.*", "v"),
-                Project.DEFAULT_VERSION, "v")
+                Project.DEFAULT_VERSION)
 
         then:
         v == "1.0.0"
@@ -71,7 +71,7 @@ some commit #2
         def v = picker.pickNextVersion(
                 Optional.of(Version.valueOf("1.0.0")),
                 new VersionConfig("1.0.*", "v"),
-                Project.DEFAULT_VERSION, "v")
+                Project.DEFAULT_VERSION)
 
         then:
         v == "1.0.2"
@@ -88,7 +88,7 @@ some commit
         def v = picker.pickNextVersion(
                 Optional.of(Version.valueOf("1.0.0")),
                 new VersionConfig("1.0.*", ""),
-                Project.DEFAULT_VERSION, "")
+                Project.DEFAULT_VERSION)
 
         then:
         v == "1.0.1"


### PR DESCRIPTION
Refactor **NextVersionPicker** class and remove duplicated _'tagPrefix'_ parameter from _'pickNextVersion()'_, as _'VersionConfig config'_ which is parameter in that method, already has field _'tagPrefix'_. This commit also refactors unit tests regarding changes made in the method definition.