### PR TITLE
Add feature to use version from annotated tag

### DIFF
--- a/src/main/java/org/shipkit/auto/version/PreviousVersionFinder.java
+++ b/src/main/java/org/shipkit/auto/version/PreviousVersionFinder.java
@@ -14,14 +14,14 @@ class PreviousVersionFinder {
      * Finds previous version based on the version specification
      */
     Optional<Version> findPreviousVersion(Collection<Version> versions, VersionConfig config) {
-        if (!config.isWildcard()) {
+        if (config.getRequestedVersion().isPresent() && !config.isWildcard()) {
             //Requested version is a concrete version like 1.0.0 (no wildcard).
             //We just find the previous version
-            return findPrevious(versions, Version.valueOf(config.toString()));
+            return findPrevious(versions, Version.valueOf(config.getRequestedVersion().get()));
         }
 
         Optional<Version> max = versions.stream()
-                .filter(v -> v.satisfies(config.toString()))
+                .filter(v -> v.satisfies(config.getRequestedVersion().get()))
                 .max(Version::compareTo);
 
         if (max.isPresent()) {

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
@@ -29,6 +29,20 @@ class AutoVersionTest extends TmpFolderSpecification {
         v.previousVersion == "1.0.1"
     }
 
+    def "happy path smoke test when no version property"() {
+        //others scenarios are covered in other test classes
+        versionFile << "version="
+        runner.run("git", "tag") >> "v1.0.4"
+        runner.run("git", "describe", "--tags") >> "v1.0.5"
+
+        when:
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
+
+        then:
+        v.version == "1.0.5"
+        v.previousVersion == "1.0.4"
+    }
+
     def "no build failure when deducting versions fails"() {
         versionFile << "version=1.0.*"
         runner.run("git", "tag") >> "v1.0.1"

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -117,4 +117,16 @@ some commit
         then:
         v == "1.1.0"
     }
+
+    def "picks version when no config file and not checked out on valid tag"() {
+        runner.run("git", "describe", "--tags") >> "v1.1.0"
+
+        when:
+        def v = picker.pickNextVersion(Optional.empty(),
+                new VersionConfig(null,"ver-"),
+                Project.DEFAULT_VERSION)
+
+        then:
+        v == "0.0.1"
+    }
 }

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -93,4 +93,28 @@ some commit
         then:
         v == "1.0.1"
     }
+
+    def "picks version when no config file and not checked out on tag"() {
+        runner.run("git", "describe", "--tags") >> "v1.1.0-1-sha12345"
+
+        when:
+        def v = picker.pickNextVersion(Optional.empty(),
+                new VersionConfig(null,"v"),
+                Project.DEFAULT_VERSION)
+
+        then:
+        v == "1.1.0"
+    }
+
+    def "picks version when no config file and checked out on tag"() {
+        runner.run("git", "describe", "--tags") >> "v1.1.0"
+
+        when:
+        def v = picker.pickNextVersion(Optional.empty(),
+                new VersionConfig(null,"v"),
+                Project.DEFAULT_VERSION)
+
+        then:
+        v == "1.1.0"
+    }
 }

--- a/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
@@ -14,25 +14,21 @@ class VersionConfigTest extends TmpFolderSpecification {
 
     def "no file"() {
         when:
-        parseVersionFile(new File("missing file"))
+        def configResult = parseVersionFile(new File("missing file"))
 
         then:
-        def e = thrown(ShipkitAutoVersionException)
-        e.message == "[shipkit-auto-version] Please create file 'version.properties' with a valid 'version' property, " +
-                "for example 'version=1.0.*'"
-        e.cause != null
+        !configResult.getRequestedVersion().isPresent()
+        configResult.getTagPrefix() == "v"
     }
 
     def "missing 'version' property"() {
-        def f = writeFile("noversion=missing")
-
         when:
-        parseVersionFile(f)
+        def f = writeFile("noversion=missing")
+        def configResult = parseVersionFile(f)
 
         then:
-        def e = thrown(ShipkitAutoVersionException)
-        e.message == "[shipkit-auto-version] File '" + f.name + "' is missing the 'version' property\n" +
-                "  Correct examples: 'version=1.0.*', 'version=2.10.100'"
+        !configResult.getRequestedVersion().isPresent()
+        configResult.getTagPrefix() == "v"
     }
 
     def "supports select types of versions"() {

--- a/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
@@ -21,9 +21,19 @@ class VersionConfigTest extends TmpFolderSpecification {
         configResult.getTagPrefix() == "v"
     }
 
-    def "missing 'version' property"() {
+    def "missing version property"() {
         when:
         def f = writeFile("noversion=missing")
+        def configResult = parseVersionFile(f)
+
+        then:
+        !configResult.getRequestedVersion().isPresent()
+        configResult.getTagPrefix() == "v"
+    }
+
+    def "version property empty"() {
+        when:
+        def f = writeFile("version=")
         def configResult = parseVersionFile(f)
 
         then:


### PR DESCRIPTION
Previous plugin behaviour didn't allow missing `version.properties` file nor empty `version` property in the file. This commit adds a behaviour that allows such configuration and deducts version from tag that code is checked out on.
This functionality is useful for teams that prefer releasing "on demand" and also allows increasing version number as needed, not based on number of commits pushed as in default behaviour with `version` property set. To use this new simplified behaviour no other configuration option than missing `version` is needed.

As said implemented feature deducts version based on tag on which a code is checked out. If the tag is valid (has same prefix as configured or default _'v'_ and version number is valid) deducted version is same as version in tag. If other tags that are valid are found, `previousVersion` which is exposed by the plugin, is a version with highest number less than deducted version (eg. for tag `v1.1.5` plugin deducts version number `1.1.5` and assuming that tag `v1.1.4` exists, exposed `previousVersion` is `1.1.4`). If code is not checked out on a valid tag and `version` is not set as property the plugin deducts version `0.0.1`.

To implement this behaviour getter for `requestedVersion()` in `'VersionConfig` class was added, and it returns Optional, which is tested  in `NextVersionPicker` and `PreviousVersionFinder` classes for containing a value, and further logic in these classes is based upon this check for `requestedVersion`. Also `deductVersion()` method in `AutoVersion` checks if `requestedVersion` is found in configuration, and if not `previousVersion` is being found using newly deducted version which is passed as argument to `findPreviousVersion()`.
New behaviour is tested by two new unit tests in `NextVersionPickerTest`, two tests ("no file" and "missing version property") refactored in `VersionConfigTest` and was also tested manually by building test project with various configuration options.

This PR resolves #1