### PR TITLE
Improve 'no version property' feature

### DIFF
--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -8,6 +8,10 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.shipkit.auto.version.TagConvention.isVersionTag;
+import static org.shipkit.auto.version.VersionConfig.isSupportedVersion;
+import static org.shipkit.auto.version.VersionConfig.isSnapshot;
+
 /**
  * Picks the next version to use.
  */
@@ -30,13 +34,18 @@ class NextVersionPicker {
         }
 
         if (!config.getRequestedVersion().isPresent()) {
-            String tag = runner.run("git", "describe", "--tags");
-            Pattern pattern = Pattern.compile(config.getTagPrefix() + "\\d+\\.\\d+\\.\\d+");
-            Matcher matcher = pattern.matcher(tag);
+            String tag = runner.run("git", "describe", "--tags").trim();
             String result;
-            if (matcher.find()) {
-                result = matcher.group().substring(config.getTagPrefix().length());
-                explainVersion(log, result, "deducted version based on tag: '" + config.getTagPrefix() + result + "'");
+            if (isVersionTag(tag, config.getTagPrefix()) && isSupportedVersion(tag.substring(config.getTagPrefix().length()))) {
+                result = tag.substring(config.getTagPrefix().length());
+                explainVersion(log, result, "deducted version based on tag: '" + tag + "'");
+            } else if (isVersionTag(tag, config.getTagPrefix()) && isSnapshot(tag, config.getTagPrefix())){
+                Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+");
+                Matcher matcher = pattern.matcher(tag);
+                matcher.find();
+                result = Version.valueOf(matcher.group()).incrementPatchVersion("SNAPSHOT").toString();
+                explainVersion(log, result,
+                        "deducted snapshot based on tag: '" + config.getTagPrefix() + matcher.group() + "'");
             } else {
                 result = "0.0.1";
                 explainVersion(log, result, "found no version property and the code is not checked out on a valid tag");

--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.shipkit.auto.version.TagConvention.isVersionTag;
 import static org.shipkit.auto.version.VersionConfig.isSupportedVersion;
 import static org.shipkit.auto.version.VersionConfig.isSnapshot;
 
@@ -36,10 +35,10 @@ class NextVersionPicker {
         if (!config.getRequestedVersion().isPresent()) {
             String tag = runner.run("git", "describe", "--tags").trim();
             String result;
-            if (isVersionTag(tag, config.getTagPrefix()) && isSupportedVersion(tag.substring(config.getTagPrefix().length()))) {
+            if (isSupportedVersion(tag, config.getTagPrefix())) {
                 result = tag.substring(config.getTagPrefix().length());
                 explainVersion(log, result, "deducted version based on tag: '" + tag + "'");
-            } else if (isVersionTag(tag, config.getTagPrefix()) && isSnapshot(tag, config.getTagPrefix())){
+            } else if (isSnapshot(tag, config.getTagPrefix())){
                 Pattern pattern = Pattern.compile("\\d+\\.\\d+\\.\\d+");
                 Matcher matcher = pattern.matcher(tag);
                 matcher.find();

--- a/src/main/java/org/shipkit/auto/version/TagConvention.java
+++ b/src/main/java/org/shipkit/auto/version/TagConvention.java
@@ -6,13 +6,6 @@ package org.shipkit.auto.version;
 class TagConvention {
 
     /**
-     * Informs if given git tag is supported
-     */
-    static boolean isVersionTag(String gitTag, String tagPrefix) {
-        return gitTag.startsWith(tagPrefix);
-    }
-
-    /**
      * Creates Git tag name based on supported convention
      */
     static String tagFor(String version, String tagPrefix) {

--- a/src/main/java/org/shipkit/auto/version/VersionConfig.java
+++ b/src/main/java/org/shipkit/auto/version/VersionConfig.java
@@ -90,17 +90,28 @@ class VersionConfig {
     }
 
     /**
-     * Informs if given version is supported by our system.
+     * Informs if given tag and version taken from this tag are supported by our system
      *
-     * @return true for simple versions like '1.0.0', '2.33.444',
+     * @return true for simple versions like '1.0.0', '2.33.444'
+     *          (provided the tag's prefix is equal to the 'tagPrefix' property),
      *          false for versions like '1.0.0-beta', '1.0', '1.foo'
+     *
      */
-    static boolean isSupportedVersion(String version) {
-        return version.matches("\\d+\\.\\d+\\.\\d+");
+    static boolean isSupportedVersion(String tag, String tagPrefix) {
+        return tag.startsWith(tagPrefix) && tag.substring(tagPrefix.length()).matches("\\d+\\.\\d+\\.\\d+");
     }
 
+    /**
+     * Informs if given tag is supported and if snapshot can be deducted
+     * as the tag is not an annotated tag
+     *
+     * @return true for tags like 'v1.0.0-1-sha1234', '2.33.444-15-dgo4d29u'
+     *          (provided the tag's prefix is equal to the 'tagPrefix' property),
+     *          false for tags like 'v1.0.0-beta', '1.0', '1.foo'
+     */
     static boolean isSnapshot(String tag, String tagPrefix) {
-        return tag.substring(tagPrefix.length()).matches("\\d+\\.\\d+\\.\\d+\\-\\d+\\-\\w+");
+        return tag.startsWith(tagPrefix)
+                && tag.substring(tagPrefix.length()).matches("\\d+\\.\\d+\\.\\d+\\-\\d+\\-\\w+");
     }
 
     public String toString() {

--- a/src/main/java/org/shipkit/auto/version/VersionConfig.java
+++ b/src/main/java/org/shipkit/auto/version/VersionConfig.java
@@ -99,6 +99,10 @@ class VersionConfig {
         return version.matches("\\d+\\.\\d+\\.\\d+");
     }
 
+    static boolean isSnapshot(String tag, String tagPrefix) {
+        return tag.substring(tagPrefix.length()).matches("\\d+\\.\\d+\\.\\d+\\-\\d+\\-\\w+");
+    }
+
     public String toString() {
         return requestedVersion;
     }

--- a/src/main/java/org/shipkit/auto/version/VersionsProvider.java
+++ b/src/main/java/org/shipkit/auto/version/VersionsProvider.java
@@ -30,7 +30,7 @@ class VersionsProvider {
         Set<Version> result = new TreeSet<>();
         for (String line : tagOutput) {
             String tag = line.trim();
-            if (TagConvention.isVersionTag(tag, tagPrefix) && isSupportedVersion(tag.substring(tagPrefix.length()))) {
+            if (isSupportedVersion(tag, tagPrefix)) {
                 String v = tag.substring(tagPrefix.length());
                 Version version = Version.valueOf(v);
                 result.add(version);

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -103,7 +103,7 @@ some commit
                 Project.DEFAULT_VERSION)
 
         then:
-        v == "1.1.0"
+        v == "1.1.1-SNAPSHOT"
     }
 
     def "picks version when no config file and checked out on tag"() {
@@ -118,12 +118,12 @@ some commit
         v == "1.1.0"
     }
 
-    def "picks version when no config file and not checked out on valid tag"() {
-        runner.run("git", "describe", "--tags") >> "v1.1.0"
+    def "picks version when no config file and checked out on not valid tag"() {
+        runner.run("git", "describe", "--tags") >> "ver-1.1.0"
 
         when:
         def v = picker.pickNextVersion(Optional.empty(),
-                new VersionConfig(null,"ver-"),
+                new VersionConfig(null,"v"),
                 Project.DEFAULT_VERSION)
 
         then:

--- a/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
@@ -51,7 +51,12 @@ class VersionConfigTest extends TmpFolderSpecification {
 
         'v1.0.0'    | 'v'        | true
         'v2.33.444' | 'v'        | true
+        '1.2.3'     | ''         | true
+        'ver-1.2.3' | 'ver-'     | true
 
+        '1.2.3'     | 'v'        | false
+        'v1.1.0'    | ''         | false
+        'ver-1.2.3' | 'v'        | false
         'x'         | ''         | false
         'v1.0'      | 'v'        | false
         'v1.0.0-rc' | 'v'        | false
@@ -67,6 +72,7 @@ class VersionConfigTest extends TmpFolderSpecification {
         'v1.0.0-1-sha123'       | 'v'        | true
         '2.33.444-12-fw6i89op'  | ''         | true
 
+        'v1.0.0-1-sha123'       | 'ver-'     | false
         'v1.0.0'                | 'v'        | false
         'v1.0-2-sha123'         | 'v'        | false
         'v1.0.0-rc'             | 'v'        | false

--- a/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionConfigTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Unroll
 
 import static VersionConfig.parseVersionFile
 import static VersionConfig.isSupportedVersion
+import static org.shipkit.auto.version.VersionConfig.isSnapshot
 
 class VersionConfigTest extends TmpFolderSpecification {
 
@@ -43,17 +44,32 @@ class VersionConfigTest extends TmpFolderSpecification {
 
     def "supports select types of versions"() {
         expect:
-        isSupportedVersion(spec) == result
+        isSupportedVersion(tag, tagPrefix) == result
 
         where:
-        spec        | result
+        tag         | tagPrefix  | result
 
-        '1.0.0'     | true
-        '2.33.444'  | true
+        'v1.0.0'    | 'v'        | true
+        'v2.33.444' | 'v'        | true
 
-        'x'         | false
-        '1.0'       | false
-        '1.0.0-rc'  | false
+        'x'         | ''         | false
+        'v1.0'      | 'v'        | false
+        'v1.0.0-rc' | 'v'        | false
+    }
+
+    def "tags are not annotated and snapshots can be deducted"() {
+        expect:
+        isSnapshot(tag, tagPrefix) == result
+
+        where:
+        tag                     | tagPrefix  | result
+
+        'v1.0.0-1-sha123'       | 'v'        | true
+        '2.33.444-12-fw6i89op'  | ''         | true
+
+        'v1.0.0'                | 'v'        | false
+        'v1.0-2-sha123'         | 'v'        | false
+        'v1.0.0-rc'             | 'v'        | false
     }
 
     @Unroll


### PR DESCRIPTION
1. When there is no version property configured and the project is being built not from tag, the plugin deducts version based on previous tag. This commit improves plugin's behaviour in such situation with increasing patch version number, taken from last tag, by 1 and adding `-SNAPSHOT` suffix. This solves #77

2. Additionally this commit fixes bug: when `version` property is not present and `tagPrefix` has no value set (`tagPrefix=`), current plugin version wrongly picks version based on tag but should pick `0.0.1`.  Also corrected unit test for behaviour when there is no config file and code is checked out on not valid tag.