### PR TITLE
Add behaviour for no tags present

### DIFF
--- a/src/main/java/org/shipkit/auto/version/AutoVersion.java
+++ b/src/main/java/org/shipkit/auto/version/AutoVersion.java
@@ -64,7 +64,7 @@ class AutoVersion {
         } catch (Exception e) {
             String message = "caught an exception, falling back to reasonable default";
             log.debug("shipkit-auto-version " + message, e);
-            String v = config.getRequestedVersion().get().replace("*", "unspecified");
+            String v = config.getRequestedVersion().orElse("0.0.1-SNAPSHOT").replace("*", "unspecified");
             explainVersion(log, v, message + "\n  - run with --debug for more info");
             return new DeductedVersion(v, previousVersion, config.getTagPrefix());
         }

--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -33,8 +33,17 @@ class NextVersionPicker {
         }
 
         if (!config.getRequestedVersion().isPresent()) {
-            String tag = runner.run("git", "describe", "--tags").trim();
+            String tag;
             String result;
+
+            try {
+                tag = runner.run("git", "describe", "--tags").trim();
+            } catch (Exception e) {
+                result = "0.0.1-SNAPSHOT";
+                explainVersion(log, result, "couldn't find tags in project");
+                return result;
+            }
+
             if (isSupportedVersion(tag, config.getTagPrefix())) {
                 result = tag.substring(config.getTagPrefix().length());
                 explainVersion(log, result, "deducted version based on tag: '" + tag + "'");

--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -40,7 +40,10 @@ class NextVersionPicker {
                 tag = runner.run("git", "describe", "--tags").trim();
             } catch (Exception e) {
                 result = "0.0.1-SNAPSHOT";
-                explainVersion(log, result, "couldn't find tags in project");
+                log.info("Process 'git describe --tags' exited with non-zero exit value. Assuming there are no tags. " +
+                        "Run with --debug for more.");
+                log.debug("Ignored exception from 'git describe --tags'. Assuming there are no tags.", e);
+                explainVersion(log, result, "couldn't run 'git describe --tags' (assuming there are no tags)");
                 return result;
             }
 

--- a/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/AutoVersionTest.groovy
@@ -58,4 +58,21 @@ class AutoVersionTest extends TmpFolderSpecification {
                 "  - reason: shipkit-auto-version caught an exception, falling back to reasonable default\n" +
                 "  - run with --debug for more info")
     }
+
+    def "no build failure when no version config present and deducting versions fails"() {
+        runner.run("git", "tag") >> {
+            throw new Exception()
+        }
+
+        when:
+        def v = autoVersion.deductVersion(log, Project.DEFAULT_VERSION)
+
+        then:
+        v.version == "0.0.1-SNAPSHOT"
+        v.previousVersion == null
+        1 * log.debug("shipkit-auto-version caught an exception, falling back to reasonable default", _ as Exception)
+        1 * log.lifecycle("Building version '0.0.1-SNAPSHOT'\n" +
+                "  - reason: shipkit-auto-version caught an exception, falling back to reasonable default\n" +
+                "  - run with --debug for more info")
+    }
 }

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -129,4 +129,19 @@ some commit
         then:
         v == "0.0.1"
     }
+
+    def "picks version when no tags found in project"() {
+        runner.run("git", "describe", "--tags") >> {
+            throw new ShipkitAutoVersionException("Problems executing command")
+        }
+
+        when:
+        def v = picker.pickNextVersion(Optional.empty(),
+                new VersionConfig(null,"v"),
+                Project.DEFAULT_VERSION)
+
+        then:
+        v == "0.0.1-SNAPSHOT"
+
+    }
 }


### PR DESCRIPTION
In AutoVersion in catch block the presence of the Optional was not checked; now it deducts version based on requestedVersion from config, and if it is not present `orElse()` returns fallback value for version: `0.0.1-SNAPSHOT`. This fixes #82 and also resolves #83 but additionally tag info finding is moved to `try-catch` block in `pickNextVersion()` - when an exception is caught fallback value for version is returned and more detailed explanation (than general one in AutoVersion) is logged. It is now also more visible in `NextVersionPicker` that `run("git", "describe", "--tags")` can throw an Exception.