### PR TITLE
Corrected NextVersionPicker

### DIFF
--- a/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
+++ b/src/main/java/org/shipkit/auto/version/NextVersionPicker.java
@@ -58,7 +58,7 @@ class NextVersionPicker {
                 explainVersion(log, result,
                         "deducted snapshot based on tag: '" + config.getTagPrefix() + matcher.group() + "'");
             } else {
-                result = "0.0.1";
+                result = "0.0.1-SNAPSHOT";
                 explainVersion(log, result, "found no version property and the code is not checked out on a valid tag");
             }
 

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -127,7 +127,7 @@ some commit
                 Project.DEFAULT_VERSION)
 
         then:
-        v == "0.0.1"
+        v == "0.0.1-SNAPSHOT"
     }
 
     def "picks version when no tags found in project"() {


### PR DESCRIPTION
Added `-SNAPSHOT` suffix to version deduced when no version is specified and code is not checked out on valid tag. In such condition more desirable behaviour is to pick a snapshot, so in such condition the plugin will deduce `0.0.1-SNAPSHOT`, not `0.0.1`.