### PR TITLE
Support non-server, 4-part versions like 1.2.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This way, you don't need to do any "version bump" commits in every release!
 This project is inspired on [Axion plugin](https://github.com/allegro/axion-release-plugin), and few others, listed later in this document.
 
 ```shipkit-auto-version``` plugin is **tiny** and has a single dependency on [jSemver](https://github.com/zafarkhaja/jsemver).
-It is a safe dependency because it is tiny, has no dependencies, and it is final (no code changes since 2015 - it wraps semver protocol that had [no changes since 2013](https://github.com/semver/semver/tree/v2.0.0)).
+It is a safe dependency because it is tiny, has no dependencies, and it is final (no code changes since 2015 - it wraps semver protocol that as of 2022 had [no changes since 2013](https://github.com/semver/semver/tree/v2.0.0)).
 
 Do you want to automate changelog generation?
 Check out [shipkit-changelog](https://github.com/shipkit/shipkit-changelog) plugin that neatly integrate with ```shipkit-auto-version``` plugin.
@@ -158,15 +158,16 @@ When the plugin is applied to the project it will:
    - identifies the latest (newest) version matching version spec
    - compares the version with the version spec:
 
-| case | spec  | latest tag | -Pversion=      | # of commits    | result          | description                          |
-|------|-------|------------|-----------------|-----------------|-----------------|--------------------------------------|
-| a    | 1.0.* | v1.0.5     |                 | 0               | 1.0.5           | zero new commits                     |
-| b    | 1.0.* | v1.0.5     |                 | 2               | 1.0.7           | two new commits                      |
-| c    | 1.0.* | v1.0.5     |                 | 5 (2 merge + 1) | 1.0.8           | two merge commits and new one on top |
-| d    | 1.1.* | v1.0.5     |                 | 5               | 1.1.0           | first x.y.0 version                  |
-| e    | 2.0.* | v1.0.5     |                 | 5               | 2.0.0           | first z.0.0 version                  |
-| f    | 1.\*.5|            |                 |                 | error           | unsupported format                   |
-| g    | 1.0.* | v1.0.5     | 1.0.10-SNAPSHOT | [any]           | 1.0.10-SNAPSHOT | version overridden from CLI argument |
+| case | spec    | latest tag | -Pversion=      | # of commits    | result          | description                             |
+|------|---------|------------|-----------------|-----------------|-----------------|-----------------------------------------|
+| a    | 1.0.*   | v1.0.5     |                 | 0               | 1.0.5           | zero new commits                        |
+| b    | 1.0.*   | v1.0.5     |                 | 2               | 1.0.7           | two new commits                         |
+| c    | 1.0.*   | v1.0.5     |                 | 5 (2 merge + 1) | 1.0.8           | two merge commits and new one on top    |
+| d    | 1.1.*   | v1.0.5     |                 | 5               | 1.1.0           | first x.y.0 version                     |
+| e    | 2.0.*   | v1.0.5     |                 | 5               | 2.0.0           | first z.0.0 version                     |
+| f    | 1.\*.5  |            |                 |                 | error           | unsupported format                      |
+| g    | 1.0.*   | v1.0.5     | 1.0.10-SNAPSHOT | [any]           | 1.0.10-SNAPSHOT | version overridden from CLI argument    |
+| e    | 1.0.0.* | v1.0.0.5   |                 | 1               | 1.0.0.6         | we support 4-part versions (non-semver) |
 
 - in case a),b) we are resolving the wildcard based on # of commits on top of the tag
    - run `git log` to identify # of commits
@@ -186,6 +187,7 @@ When the plugin is applied to the project it will:
 
 - in case d),e) use '0' as patch version
 - in case g) the user manually specified the version on the command line
+- in case e) we support 4-part versions like 1.2.3.4 (note that those versions are not semver compatible)
 
 ### When releasing every tag
 
@@ -202,13 +204,13 @@ When tag does not match the convention (`tagPrefix`) the plugin picks fallback v
 
 #### Examples:
 
-| case | version.properties        | checked out on  | -Pversion=      | result
-|------|---------------------------|-----------------|-----------------|------------------------------------------------------
-| h    | (empty/missing)           | v1.0.5          |                 | 1.0.5 (no 'tagPrefix' specified, default is 'v')
-| i    | tagPrefix=ver-            | ver-1.0.5       |                 | 1.0.5 ('tagPrefix' matches the tag)
-| j    | (empty/missing)           | v1.0.5-2-sha123 |                 | 1.0.6-SNAPSHOT (ahead of "v1.0.5" tag)
-| k    | tagPrefix=                | v1.0.5          |                 | 0.0.1-SNAPSHOT (empty tag prefix doesn't match 'v')
-| l    | (empty/missing)           | v1.0.2          | 1.0.5-SNAPSHOT  | 1.0.5-SNAPSHOT (version overridden from CLI argument)
+| case | version.properties        | checked out on  | -Pversion=      | result                                               |
+|------|---------------------------|-----------------|-----------------|------------------------------------------------------|
+| h    | (empty/missing)           | v1.0.5          |                 | 1.0.5 (no 'tagPrefix' specified, default is 'v')     |
+| i    | tagPrefix=ver-            | ver-1.0.5       |                 | 1.0.5 ('tagPrefix' matches the tag)                  |
+| j    | (empty/missing)           | v1.0.5-2-sha123 |                 | 1.0.6-SNAPSHOT (ahead of "v1.0.5" tag)               |
+| k    | tagPrefix=                | v1.0.5          |                 | 0.0.1-SNAPSHOT (empty tag prefix doesn't match 'v')  |
+| l    | (empty/missing)           | v1.0.2          | 1.0.5-SNAPSHOT  | 1.0.5-SNAPSHOT (version overridden from CLI argument)|
 
 ## Similar plugins
 

--- a/src/integTest/groovy/org/shipkit/auto/version/AutoVersionPluginIntegTest.groovy
+++ b/src/integTest/groovy/org/shipkit/auto/version/AutoVersionPluginIntegTest.groovy
@@ -30,6 +30,14 @@ class AutoVersionPluginIntegTest extends Specification {
         run("tasks")
     }
 
+    def "uses four-number version scheme"() {
+        file("version.properties") << "version=1.0.0.1"
+        file("build.gradle") << "assert project.version == '1.0.0.1'"
+
+        expect:
+        run("tasks")
+    }
+
     File file(String path) {
         def f = new File(rootDir, path)
         if (!f.exists()) {

--- a/src/main/java/org/shipkit/auto/version/DeductedVersion.java
+++ b/src/main/java/org/shipkit/auto/version/DeductedVersion.java
@@ -1,7 +1,5 @@
 package org.shipkit.auto.version;
 
-import com.github.zafarkhaja.semver.Version;
-
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
@@ -14,13 +12,11 @@ class DeductedVersion {
     private final String version;
     private final String previousVersion;
     private final String previousTag;
-    private final String tagPrefix;
 
-    DeductedVersion(String version, Optional<Version> previousVersion, String tagPrefix) {
-        this.tagPrefix = tagPrefix;
+    DeductedVersion(String version, Optional<VersionNumber> previousVersion, String tagPrefix) {
         Objects.requireNonNull(version, "version cannot be null");
         this.version = version;
-        this.previousVersion = previousVersion.map(Version::toString).orElse(null);
+        this.previousVersion = previousVersion.map(VersionNumber::toString).orElse(null);
         this.previousTag = previousVersion.map(v -> TagConvention.tagFor(v.toString(), tagPrefix)).orElse(null);
     }
 

--- a/src/main/java/org/shipkit/auto/version/PreviousVersionFinder.java
+++ b/src/main/java/org/shipkit/auto/version/PreviousVersionFinder.java
@@ -1,7 +1,5 @@
 package org.shipkit.auto.version;
 
-import com.github.zafarkhaja.semver.Version;
-
 import java.util.Collection;
 import java.util.Optional;
 
@@ -13,16 +11,16 @@ class PreviousVersionFinder {
     /**
      * Finds previous version based on the version specification
      */
-    Optional<Version> findPreviousVersion(Collection<Version> versions, VersionConfig config) {
-        if (config.getRequestedVersion().isPresent() && !config.isWildcard()) {
+    Optional<VersionNumber> findPreviousVersion(Collection<VersionNumber> versions, VersionConfig config) {
+        if (config.getVersionSpec().isPresent() && !config.isWildcard()) {
             //Requested version is a concrete version like 1.0.0 (no wildcard).
             //We just find the previous version
-            return findPrevious(versions, Version.valueOf(config.getRequestedVersion().get()));
+            return findPrevious(versions, new VersionNumber(config.getVersionSpec().get()));
         }
 
-        Optional<Version> max = versions.stream()
-                .filter(v -> v.satisfies(config.getRequestedVersion().get()))
-                .max(Version::compareTo);
+        Optional<VersionNumber> max = versions.stream()
+                .filter(v -> v.satisfies(config.getVersionSpec().get()))
+                .max(VersionNumber::compareTo);
 
         if (max.isPresent()) {
             return max; //we found it! just return.
@@ -31,12 +29,12 @@ class PreviousVersionFinder {
         //We did not find it. This happens in example scenario:
         // versions are 0.0.1, 0.0.2 and the requested version is 0.1.*
         String newPatchVersion = config.newPatchVersion();
-        return findPrevious(versions, Version.valueOf(newPatchVersion));
+        return findPrevious(versions, new VersionNumber(newPatchVersion));
     }
 
-    private Optional<Version> findPrevious(Collection<Version> versions, Version version) {
+    private Optional<VersionNumber> findPrevious(Collection<VersionNumber> versions, VersionNumber version) {
         return versions.stream()
-                .filter(v -> v.lessThan(version))
-                .max(Version::compareTo);
+                .filter(v -> v.compareTo(version) < 0)
+                .max(VersionNumber::compareTo);
     }
 }

--- a/src/main/java/org/shipkit/auto/version/VersionNumber.java
+++ b/src/main/java/org/shipkit/auto/version/VersionNumber.java
@@ -49,11 +49,13 @@ class VersionNumber implements Comparable<VersionNumber> {
      * @param versionSpec - for example, 1.2.* or 1.2.3.*
      */
     public boolean satisfies(String versionSpec) {
-        if (fourthDigit == -1) {
+        if (fourthDigit == -1 && versionSpec.matches("^\\d+\\.\\d+\\.\\*$")) {
             return semver.satisfies(versionSpec);
+        } else if (fourthDigit != -1 && versionSpec.matches("^\\d+\\.\\d+\\.\\d+\\.\\*$")) {
+            String version = versionSpec.replaceAll("\\.\\*$", "");
+            return semver.satisfies(version);
         }
-        String version = versionSpec.replaceAll("\\.\\*$", "");
-        return semver.satisfies(version);
+        return false;
     }
 
     public VersionNumber incrementBy(int count) {

--- a/src/main/java/org/shipkit/auto/version/VersionNumber.java
+++ b/src/main/java/org/shipkit/auto/version/VersionNumber.java
@@ -1,0 +1,82 @@
+package org.shipkit.auto.version;
+
+import com.github.zafarkhaja.semver.Version;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class VersionNumber implements Comparable<VersionNumber> {
+
+    private int fourthDigit = -1;
+    private Version semver;
+
+    public VersionNumber(String version) {
+        try {
+            semver = Version.valueOf(version);
+            return;
+        } catch (Exception e) {
+            //fall back to 4-part number
+        }
+
+        Matcher matcher = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)\\.(\\d+)$").matcher(version);
+        if (!matcher.matches()) {
+            throw new UnsupportedVersionException(version);
+        }
+        String g1 = matcher.group(1);
+        semver = Version.valueOf(g1);
+
+        String g2 = matcher.group(2);
+        try {
+            this.fourthDigit = Integer.parseInt(g2);
+        } catch (NumberFormatException e) {
+            throw new UnsupportedVersionException(version);
+        }
+    }
+
+    @Override
+    public int compareTo(VersionNumber v) {
+        int result = this.semver.compareTo(v.semver);
+        if (result != 0) {
+            return result;
+        }
+
+        return Integer.compare(fourthDigit, v.fourthDigit);
+    }
+
+    /**
+     * Examples: 1.2.3 satisfies 1.2.*, 1.2.3.4 satisfies 1.2.3.*
+     *
+     * @param versionSpec - for example, 1.2.* or 1.2.3.*
+     */
+    public boolean satisfies(String versionSpec) {
+        if (fourthDigit == -1) {
+            return semver.satisfies(versionSpec);
+        }
+        String version = versionSpec.replaceAll("\\.\\*$", "");
+        return semver.satisfies(version);
+    }
+
+    public VersionNumber incrementBy(int count) {
+        if (fourthDigit == -1) {
+            return new VersionNumber(
+                            semver.getMajorVersion() + "." +
+                            semver.getMinorVersion() + "." +
+                                    (semver.getPatchVersion() + count));
+        }
+        return new VersionNumber(semver.toString() + "." + (fourthDigit + count));
+    }
+
+    public String toString() {
+        if (fourthDigit == -1) {
+            return semver.toString();
+        }
+
+        return semver.toString() + "." + fourthDigit;
+    }
+
+    public static class UnsupportedVersionException extends RuntimeException {
+        public UnsupportedVersionException(String version) {
+            super("Unsupported version: " + version + ". Expected semver OR 4-part number like 1.2.3.4");
+        }
+    }
+}

--- a/src/main/java/org/shipkit/auto/version/VersionsProvider.java
+++ b/src/main/java/org/shipkit/auto/version/VersionsProvider.java
@@ -1,7 +1,5 @@
 package org.shipkit.auto.version;
 
-import com.github.zafarkhaja.semver.Version;
-
 import java.util.Collection;
 import java.util.Set;
 import java.util.TreeSet;
@@ -23,17 +21,16 @@ class VersionsProvider {
      *
      * @param tagPrefix tag prefix
      */
-    Collection<Version> getAllVersions(String tagPrefix) {
+    Collection<VersionNumber> getAllVersions(String tagPrefix) {
         String gitOutput = runner.run("git", "tag");
         String[] tagOutput = gitOutput.split("\\R");
 
-        Set<Version> result = new TreeSet<>();
+        Set<VersionNumber> result = new TreeSet<>();
         for (String line : tagOutput) {
             String tag = line.trim();
             if (isSupportedVersion(tag, tagPrefix)) {
                 String v = tag.substring(tagPrefix.length());
-                Version version = Version.valueOf(v);
-                result.add(version);
+                result.add(new VersionNumber(v));
             }
         }
 

--- a/src/test/groovy/org/shipkit/auto/version/DeductedVersionTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/DeductedVersionTest.groovy
@@ -1,20 +1,19 @@
 package org.shipkit.auto.version
 
-import com.github.zafarkhaja.semver.Version
 import spock.lang.Specification
 
 class DeductedVersionTest extends Specification {
 
     def "previous version"() {
         expect:
-        "0.0.9" == new DeductedVersion("1.0.0", Optional.of(Version.valueOf("0.0.9")), "v").previousVersion
+        "0.0.9" == new DeductedVersion("1.0.0", Optional.of(new VersionNumber("0.0.9")), "v").previousVersion
         null == new DeductedVersion("1.0.0", Optional.empty(), "v").previousVersion
     }
 
     def "previous tag"() {
         expect:
-        "v0.0.9" == new DeductedVersion("1.0.0", Optional.of(Version.valueOf("0.0.9")), "v").previousTag
-        "0.0.9" == new DeductedVersion("1.0.0", Optional.of(Version.valueOf("0.0.9")), "").previousTag
+        "v0.0.9" == new DeductedVersion("1.0.0", Optional.of(new VersionNumber("0.0.9")), "v").previousTag
+        "0.0.9" == new DeductedVersion("1.0.0", Optional.of(new VersionNumber("0.0.9")), "").previousTag
         null == new DeductedVersion("1.0.0", Optional.empty(), "v").previousTag
     }
 }

--- a/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/NextVersionPickerTest.groovy
@@ -51,7 +51,7 @@ class NextVersionPickerTest extends Specification {
     def "picks new patch version when no matching previous versions"() {
         when:
         def v = picker.pickNextVersion(
-                Optional.of(Version.valueOf("0.0.9")),
+                Optional.of(new VersionNumber("0.0.9")),
                 new VersionConfig("1.0.*", "v"),
                 Project.DEFAULT_VERSION)
 
@@ -69,7 +69,7 @@ some commit #2
 
         when:
         def v = picker.pickNextVersion(
-                Optional.of(Version.valueOf("1.0.0")),
+                Optional.of(new VersionNumber("1.0.0")),
                 new VersionConfig("1.0.*", "v"),
                 Project.DEFAULT_VERSION)
 
@@ -86,7 +86,7 @@ some commit
 
         when:
         def v = picker.pickNextVersion(
-                Optional.of(Version.valueOf("1.0.0")),
+                Optional.of(new VersionNumber("1.0.0")),
                 new VersionConfig("1.0.*", ""),
                 Project.DEFAULT_VERSION)
 
@@ -104,6 +104,18 @@ some commit
 
         then:
         v == "1.1.1-SNAPSHOT"
+    }
+
+    def "picks 4-part version when no config file and not checked out on tag"() {
+        runner.run("git", "describe", "--tags") >> "v1.2.3.4-1-sha12345"
+
+        when:
+        def v = picker.pickNextVersion(Optional.empty(),
+                new VersionConfig(null,"v"),
+                Project.DEFAULT_VERSION)
+
+        then:
+        v == "1.2.3.5-SNAPSHOT"
     }
 
     def "picks version when no config file and checked out on tag"() {

--- a/src/test/groovy/org/shipkit/auto/version/PreviousVersionFinderTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/PreviousVersionFinderTest.groovy
@@ -3,8 +3,6 @@ package org.shipkit.auto.version
 
 import spock.lang.Specification
 
-import static com.github.zafarkhaja.semver.Version.valueOf
-
 class PreviousVersionFinderTest extends Specification {
 
     def "finds previous of concrete version"() {
@@ -24,7 +22,7 @@ class PreviousVersionFinderTest extends Specification {
 
     String prev(Collection<String> versions, String target) {
         new PreviousVersionFinder().findPreviousVersion(
-                versions.collect { valueOf(it) },
+                versions.collect { new VersionNumber(it) },
                 new VersionConfig(target, "v")).orElse(null)
     }
 }

--- a/src/test/groovy/org/shipkit/auto/version/VersionNumberTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionNumberTest.groovy
@@ -68,4 +68,19 @@ class VersionNumberTest extends Specification {
         "1.2.3"     |"1.2.3"
         "1.2.3.4"   |"1.2.3.4"
     }
+
+    def "satisfies spec"() {
+        expect:
+        new VersionNumber(version).satisfies(spec) == result
+
+        where:
+        version     | spec       | result
+        '1.0.0'     | '1.0.0'    | false
+        '1.0.0'     | '1.0.*'    | true
+        '1.0.4'     | '1.0.*'    | true
+        '1.0.0.0'   | '1.0.0.*'  | true
+        '1.0.0.5'   | '1.0.0.*'  | true
+        '1.0.0'     | '1.0.0.*'  | false
+        '1.0.0.0'   | '1.0.*'    | false
+    }
 }

--- a/src/test/groovy/org/shipkit/auto/version/VersionNumberTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionNumberTest.groovy
@@ -1,0 +1,71 @@
+package org.shipkit.auto.version
+
+
+import spock.lang.Specification
+
+import static org.shipkit.auto.version.VersionNumber.*
+
+class VersionNumberTest extends Specification {
+
+    def "validates version"() {
+        expect:
+        try {
+            new VersionNumber(version)
+        } catch (UnsupportedVersionException e) {
+            assert e.message.contains(version)
+        }
+
+        where:
+        version << ["", "foo", "1", "1.2", "1.2.3.4.5"]
+    }
+
+    def "string representation"() {
+        expect:
+        new VersionNumber(version).toString() == text
+
+        where:
+        version        | text
+        "1.2.3"        | "1.2.3"
+        "1.2.3-build1" | "1.2.3-build1"
+        "1.2.3.4"      | "1.2.3.4"
+    }
+
+    def "increments by specific count"() {
+        expect:
+        new VersionNumber(version).incrementBy(count).toString() == result
+
+        where:
+        version        | count  | result
+        "1.2.3"        | 0      | "1.2.3"
+        "1.2.3"        | 1      | "1.2.4"
+        "1.2.3"        | 10     | "1.2.13"
+
+        "1.2.3.4"      | 0      | "1.2.3.4"
+        "1.2.3.4"      | 1      | "1.2.3.5"
+        "1.2.3.4"      | 10     | "1.2.3.14"
+    }
+
+    def "different numbers comparison"() {
+        expect:
+        new VersionNumber(left) > new VersionNumber(right)
+        new VersionNumber(right) < new VersionNumber(left)
+
+        where:
+        left        |right
+        "1.2.3"     |"1.2.2"
+        "5.0.0"     |"4.9.9"
+        "1.2.3"     |"1.2.2.4"
+        "1.2.3.4"   |"1.2.2.3"
+    }
+
+    def "equal numbers comparison"() {
+        expect:
+        new VersionNumber(left) == new VersionNumber(right)
+        new VersionNumber(right) == new VersionNumber(left)
+
+        where:
+        left        |right
+        "1.2.3"     |"1.2.3"
+        "1.2.3.4"   |"1.2.3.4"
+    }
+}

--- a/src/test/groovy/org/shipkit/auto/version/VersionsProviderTest.groovy
+++ b/src/test/groovy/org/shipkit/auto/version/VersionsProviderTest.groovy
@@ -25,16 +25,16 @@ class VersionsProviderTest extends Specification {
             v1.0.2
             v2.0.0
             v22.333.4444
+            v1.0.0.0
             
             foo
             1.0.0
-            v1.0
-            v1.0.0.0
+            v1.0            
             v1.0.0-beta
         """
 
         expect:
-        provider.getAllVersions("v").toString() == "[1.0.1, 1.0.2, 2.0.0, 22.333.4444]"
+        provider.getAllVersions("v").toString() == "[1.0.0.0, 1.0.1, 1.0.2, 2.0.0, 22.333.4444]"
     }
 
     def "gets all versions when no tag prefix"() {

--- a/version.properties
+++ b/version.properties
@@ -1,3 +1,3 @@
 # Version of produced binaries.
 # The '*' part is automatically resolved by shipkit-auto-version Gradle plugin (https://github.com/shipkit/shipkit-auto-version).
-version=1.1.*
+version=1.2.*


### PR DESCRIPTION
This makes auto version support semver and simple non-semver versions like 1.2.3.4

Fixes #109

Tested e2e with Iceberg (https://github.com/ljfgem/iceberg/tree/auto_release)